### PR TITLE
fix: loading fixes for useGet and useGetControlled

### DIFF
--- a/src/hooks/useGet.ts
+++ b/src/hooks/useGet.ts
@@ -27,7 +27,7 @@ export const useGet = <
 
     const operation = apiActionHandler.operationUtility.getOperationGet(id);
     const loading = useSelector((state: RootState) => {
-        return StateHelper.getLoading(state, operation, RequestMethod.Get, id);
+        return StateHelper.getLoading(state, operation, RequestMethod.Get);
     });
     const record = useSelector((state: RootState) => {
         return (apiActionHandler.apiSelector.getSingle(

--- a/src/hooks/useGetControlled.ts
+++ b/src/hooks/useGetControlled.ts
@@ -38,7 +38,7 @@ export const useGetControlled = <
 
     const operation = apiActionHandler.operationUtility.getOperationGet(id);
     const loading = useSelector((state: RootState) => {
-        return StateHelper.getLoading(state, operation, RequestMethod.Get, id);
+        return StateHelper.getLoading(state, operation, RequestMethod.Get);
     });
 
     const record = useSelector((state: RootState) => {

--- a/src/services/StateHelper/StateHelper.ts
+++ b/src/services/StateHelper/StateHelper.ts
@@ -8,9 +8,8 @@ export class StateHelper {
         state: RootState,
         operation: Operation,
         requestMethod: RequestMethod,
-        id?: string,
     ) {
-        const meta = StateHelper.getMeta(state, operation, requestMethod, id);
+        const meta = StateHelper.getMeta(state, operation, requestMethod);
 
         if (meta === undefined) {
             return [];
@@ -29,12 +28,8 @@ export class StateHelper {
         state: RootState,
         operation: Operation,
         requestMethod: RequestMethod,
-        id?: string,
     ) {
-        const methods =
-            id === undefined
-                ? state.apiData.meta[operation]
-                : state.apiData.meta[operation + "_" + id];
+        let methods = state.apiData.meta[operation];
 
         if (methods === undefined) {
             return undefined;
@@ -89,9 +84,8 @@ export class StateHelper {
         state: RootState,
         operation: Operation,
         requestMethod: RequestMethod,
-        id?: string,
     ) {
-        const meta = this.getMeta(state, operation, requestMethod, id);
+        const meta = this.getMeta(state, operation, requestMethod);
 
         if (meta === undefined) {
             return undefined;
@@ -108,9 +102,8 @@ export class StateHelper {
         state: RootState,
         operation: Operation,
         requestMethod: RequestMethod,
-        id?: string,
     ) {
-        const meta = this.getMeta(state, operation, requestMethod, id);
+        const meta = this.getMeta(state, operation, requestMethod);
 
         if (meta === undefined) {
             return false;


### PR DESCRIPTION
Loading attribute, exported from `useGet` and `useGetControlled` wasn't working as it tried to query the ID with StateHelper, which is written in the operation. Therefore, no state key was found. This is now fixed