### PR TITLE
Feature: fix attributes {} if  __clientGeneratedEntity only attribute

### DIFF
--- a/src/json-api-client/CustomModelPropertiesMapper.ts
+++ b/src/json-api-client/CustomModelPropertiesMapper.ts
@@ -24,14 +24,11 @@ export class CustomModelPropertiesMapper extends ModelPropertiesMapper {
             }
         });
 
-        const is__clientGeneratedEntityOnlyAttribute =
-            attributes["__clientGeneratedEntity"] !== undefined &&
-            Object.keys(attributes).length === 1;
         const isEmptyObject =
             Object.keys(attributes).length === 0 &&
             attributes.constructor === Object;
 
-        if (is__clientGeneratedEntityOnlyAttribute || isEmptyObject) {
+        if (isEmptyObject) {
             /**
              * casting to any because we need to return undefined to prevent adding empty attributes object
              */

--- a/src/json-api-client/JsonaDataFormatter.ts
+++ b/src/json-api-client/JsonaDataFormatter.ts
@@ -107,6 +107,11 @@ class JsonaDataFormatter {
             delete entity.attributes.__clientGeneratedEntity;
         }
 
+        // set attributes object to undefined if empty
+        if (entity.attributes && Object.keys(entity.attributes).length === 0) {
+            entity.attributes = undefined;
+        }
+
         return entity;
     }
 

--- a/src/tests/jsonaDataFormatter.test.tsx
+++ b/src/tests/jsonaDataFormatter.test.tsx
@@ -185,7 +185,7 @@ describe("jsonaDataFormatter", () => {
         };
         const expectedSerializedRequestData = {
             data: {
-                id: "1",
+                id: undefined,
                 type: "car",
                 attributes: undefined,
             },


### PR DESCRIPTION
- sets entity.attributes to undefined if no other attributes in that object
- covered in test, and tested with yalc on another project

 - if conditional set in CustomPropertiesMapper.ts it would create random uuid for the which is irrelevant and unnecessary.